### PR TITLE
add DaoCloud to Companys

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -135,6 +135,7 @@ docker资源汇总,随时更新，欢迎补充。
 * [Musings of Matt Williams](http://matthewkwilliams.com/)
 
 ## 创业公司
+* [DaoCloud](https://www.daocloud.io/)
 * [云栈科技](https://csphere.cn)
 * [云雀科技](https://www.alauda.cn)
 


### PR DESCRIPTION
**DaoCloud** is a cloud computing company focusing on providing Docker services to its clients. DaoCloud is the gold sponsor of DockerCon 2015, and is working closely with Docker, Inc. to build a strong partnership. DaoCloud is also a major Docker Meetup organiser in China. 

Link: www.daocloud.io
